### PR TITLE
First draft api timeout setting

### DIFF
--- a/pygrouper/__init__.py
+++ b/pygrouper/__init__.py
@@ -4,5 +4,5 @@ A simple Python 3 client for working with the Grouper WS API
 
 from .api import GrouperAPI
 from .exceptions import (
-    GrouperAPIException, GrouperAPIError
+    GrouperAPIException, GrouperAPIError, GrouperAPITimeout
 )

--- a/pygrouper/client.py
+++ b/pygrouper/client.py
@@ -2,16 +2,19 @@
 """
 
 import requests
+from .exceptions import GrouperAPIException, GrouperAPITimeout, GrouperAPIError
 
 WS_VERSIONS = [
     'v2_2_000'
 ]
 
 class GrouperClient(object):
-    def __init__(self, host, user, password, ws_version=None):
+    def __init__(self, host, user, password, ws_version=None, timeout=60):
         self._host = host
         self._api_user = user
         self._api_pass = password
+        self._timeout = timeout
+
         if ws_version == None:
             self._ws_version = 'v2_2_000'
         else:
@@ -25,13 +28,19 @@ class GrouperClient(object):
 
     def _get(self, endpoint):
         uri = self._uri(endpoint)
-        r = requests.get(uri, auth=(self._api_user, self._api_pass))
+        try:
+            r = requests.get(uri, auth=(self._api_user, self._api_pass), timeout=self._timeout)
+        except requests.exceptions.Timeout as e:
+            raise(GrouperAPITimeout(f"Timeout ({self._timeout} seconds) while waiting for the Grouper API."))
         r.raise_for_status()
         return r.json()
 
     def _put(self, endpoint):
         uri = self._uri(endpoint)
-        r = requests.put(uri, auth=(self._api_user, self._api_pass))
+        try:
+            r = requests.put(uri, auth=(self._api_user, self._api_pass), timeout=self._timeout)
+        except requests.exceptions.Timeout as e:
+            raise(GrouperAPITimeout(f"Timeout ({self._timeout} seconds) while waiting for the Grouper API."))
         r.raise_for_status()
         return r.json()
 
@@ -45,13 +54,19 @@ class GrouperClient(object):
             headers={'Content-Type': 'text/x-json'}
 
         uri = self._uri(endpoint)
-        r = requests.post(uri, auth=(self._api_user, self._api_pass), json=payload, headers=headers)
+        try:
+            r = requests.post(uri, auth=(self._api_user, self._api_pass), json=payload, headers=headers, timeout=self._timeout)
+        except requests.exceptions.Timeout as e:
+            raise(GrouperAPITimeout(f"Timeout ({self._timeout} seconds) while waiting for the Grouper API."))
         r.raise_for_status()
         return r.json()
 
     def _delete(self, endpoint):
         uri = self._uri(endpoint)
-        r = requests.delete(uri, auth=(self._api_user, self._api_pass))
+        try:
+            r = requests.delete(uri, auth=(self._api_user, self._api_pass), timeout=self._timeout)
+        except requests.exceptions.Timeout as e:
+            raise(GrouperAPITimeout(f"Timeout ({self._timeout} seconds) while waiting for the Grouper API."))
         r.raise_for_status()
         return r.json()
 

--- a/pygrouper/exceptions.py
+++ b/pygrouper/exceptions.py
@@ -10,3 +10,8 @@ class GrouperAPIError(GrouperAPIException):
     """Exception for passing errors on to the calling application"""
     def __init__(self, message):
         self.message = message
+
+class GrouperAPITimeout(GrouperAPIException):
+    """Exception for passing errors on to the calling application"""
+    def __init__(self, message):
+        self.message = message


### PR DESCRIPTION
I think I fixed a bug here by importing the various Exception classes, but I haven't had the time to read carefully the python [import docs](https://docs.python.org/3/reference/import.html#regular-packages) to fully understand.

I tested by raising an exception in the top-level of the constructor in client.py: https://github.com/OSU-IAM/pygrouper/blob/master/pygrouper/client.py#L21. 

I came across this because the new Exception class was not getting found when triggered... Importing them at the top of client.py works fine, of course.

I tried a version of the exception that needed only the configured timeout as param, which it would then inject via f-string into self.message, but I only got the integer timeout in the application log, so I reverted to the more verbose exception invocation you see here
